### PR TITLE
cache: add gopacket raw Packet

### DIFF
--- a/packetcache.go
+++ b/packetcache.go
@@ -3,6 +3,7 @@ package gopacketcache
 import (
     "time"
     "sync"
+    "github.com/google/gopacket"
 )
 
 // CachedInfo holds the cached information of one packet.
@@ -69,6 +70,12 @@ func (pcache *PacketCache) Insert(packet *Packet) error {
         return nil
     }
     return err
+}
+
+// InsertGoPacket inserts an unwrapped GoPacket packet to the cache.
+func (pcache *PacketCache) InsertGoPacket(gpacket *gopacket.Packet) error {
+    packet := Packet{*gpacket}
+    return pcache.Insert(&packet)
 }
 
 // GetCachedStats returns the cached information of the last minutes, as

--- a/packetcache_test.go
+++ b/packetcache_test.go
@@ -72,3 +72,14 @@ func TestPacketCache_OpenOffline(t *testing.T) {
         }
     }
 }
+
+func TestPacketCache_InsertGoPacket(t *testing.T) {
+    cache := NewPacketCache(10)
+    mockTime := TestTimeImpl{time.Now()}
+    cache.timeNow = mockTime.Now
+    packet, _ := getOnePacket(t)
+    err := cache.InsertGoPacket(&packet.Packet)
+    if err != nil {
+        t.Error("Insert raw packet error:", err)
+    }
+}


### PR DESCRIPTION
* Add a method that takes a gopacket.Packet and adds it to the cache.

Signed-off-by: Nikos Filippakis <aesmade@gmail.com>